### PR TITLE
Add Portuguese landing page for Codex

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+<meta charset="UTF-8">
+<title>Por que escolher o Codex</title>
+<style>
+body { font-family: Arial, sans-serif; margin: 0; padding: 0; background-color: #f5f5f5; }
+header { background-color: #292b2c; color: #fff; padding: 20px; text-align: center; }
+section { padding: 40px; max-width: 800px; margin: auto; }
+ul { list-style-type: disc; margin-left: 20px; }
+footer { background-color: #292b2c; color: #fff; padding: 10px; text-align: center; }
+</style>
+</head>
+<body>
+<header>
+<h1>Codex vs. Claude Code</h1>
+<p>Descubra como o Codex se destaca na geração de código inteligente.</p>
+</header>
+<section>
+<h2>Vantagens do Codex</h2>
+<ul>
+<li>Maior compatibilidade com ferramentas de desenvolvimento populares.</li>
+<li>Integrações robustas para automação de testes e implantação.</li>
+<li>Baseado em código aberto, permitindo personalizações flexíveis.</li>
+<li>Atualizações frequentes que acompanham as tendências do setor.</li>
+<li>Suporte à comunidade ativa e documentação abrangente.</li>
+</ul>
+<h2>Comparação com o Claude Code</h2>
+<p>Embora o Claude Code ofereça boas soluções de IA, o Codex se destaca em termos de desempenho e escalabilidade, além de fornecer exemplos práticos e consistentes que facilitam o desenvolvimento colaborativo.</p>
+</section>
+<footer>
+<p>&copy; 2025 Codex</p>
+</footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `index.html` with a simple landing page comparing Codex to Claude Code

## Testing
- `npm test` *(fails: could not find `package.json`)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686ae26ba684832ba2461a0cf850102b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new Portuguese-language webpage highlighting Codex's advantages and comparing it to Claude Code, featuring structured sections, styled layout, and a 2025 copyright notice.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->